### PR TITLE
FIX: np.int deprecation

### DIFF
--- a/spharmnet/lib/sphere.py
+++ b/spharmnet/lib/sphere.py
@@ -220,7 +220,7 @@ def legendre(n, x, tol, tstart):
         v = 9.2 - np.log(tol) / (n * factor[idx])
         w = 1 / np.log(v)
         m1 = 1 + n * factor[idx] * v * w * (1.0058 + w * (3.819 - w * 12.173))
-        m1 = np.minimum(n, np.floor(m1)).astype(np.int)
+        m1 = np.minimum(n, np.floor(m1)).astype(np.int64)
 
         Y[:, idx] = 0
         m1_unique = np.unique(m1)

--- a/spharmnet/lib/sphere.py
+++ b/spharmnet/lib/sphere.py
@@ -74,7 +74,7 @@ class TriangleSearch:
         if self.ring < ring:
             for _ in range(self.ring, ring):
                 self.adj_nn = self.adj @ self.adj_nn
-            self.nn = np.max(self.adj_nn).astype(np.int)
+            self.nn = np.max(self.adj_nn).astype(np.int64)
             self.ring = ring
 
     def barycentric(self, v, f, q, fid, area, normal):
@@ -111,7 +111,7 @@ class TriangleSearch:
 
         q_num = q.shape[0]
         qID = np.arange(q_num)
-        fid = np.zeros(q_num, dtype=np.int)
+        fid = np.zeros(q_num, dtype=np.int64)
         bary = np.zeros((q_num, 3), dtype=np.float)
 
         for k in range(1, self.nn + 1):


### PR DESCRIPTION
For numpy >= 1.20.0, there is a deprecated API for astype.(np.int) in spharmnet.lib.sphere.
np.int -> np.int64
By fixing above line, it works in numpy==1.24.4